### PR TITLE
Fix navigation back to dashboard after updating profile

### DIFF
--- a/client/src/components/ProfileForm.tsx
+++ b/client/src/components/ProfileForm.tsx
@@ -1,5 +1,6 @@
 import { ProfileData, updateProfile } from "../api-helper";
 import { Container, Box, Button, TextField } from '@mui/material';
+import { useNavigate, Link } from "react-router-dom";
 
 type User = {
   phone: string;
@@ -15,6 +16,7 @@ type Props = {
 };
 
 const ProfileForm = ({ user }: Props) => {
+  const navigate = useNavigate();
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -30,7 +32,7 @@ const ProfileForm = ({ user }: Props) => {
     };
 
     updateProfile(formValues).then(() => {
-      window.location.href = '/dashboard';
+      navigate('/dashboard');
     });
   };
 


### PR DESCRIPTION
If you set `window.location.href = '/dashboard';` you'll get a 404 for
the `/dashboard` url because it doesn't route through whatever magic
Vite uses to setup the app and authenticate and all that
